### PR TITLE
Fix the hole energy window and Fermi level

### DIFF
--- a/HamEPC/EPC_calculator.py
+++ b/HamEPC/EPC_calculator.py
@@ -1013,8 +1013,13 @@ class EPC_calculator(object):
             # so the values kept are the same as those the element-wise loop produced.
             args_hole = (enks - evbm) / self.temperature
             ks_exp = np.where(args_hole < -self.maxarg, 0.0, np.exp(args_hole))
-            eup = Hamcts.TENPM160
-            elw = 1.0
+            # ef sets the Fermi level through efermi = evbm - log(ef) * T, so ef below
+            # one puts it above the VBM (dilute holes, Fermi level in the gap) and ef
+            # above one puts it below (degenerate holes, Fermi level inside the valence
+            # bands).  Bracketing at an upper bound of one therefore excludes the
+            # degenerate case entirely; bracket symmetrically instead.
+            eup = Hamcts.TENPM80
+            elw = Hamcts.TENPP80
             for i in range(self.fermi_maxiter):
                 ef = np.sqrt(eup) * np.sqrt(elw)
                 _kse = ks_exp[:iband_edge+1] * ef

--- a/HamEPC/EPC_calculator.py
+++ b/HamEPC/EPC_calculator.py
@@ -1025,7 +1025,11 @@ class EPC_calculator(object):
                     rel_err = -Hamcts.TENPP3
                 else:
                     rel_err = (hole_density - np.abs(self.ncarrier)) / hole_density
-                if rel_err < Hamcts.TENPM5:
+                # Tested on the magnitude, as the electron branch below does.  The
+                # underflow case sets rel_err negative to mean "too few holes, raise ef",
+                # and a bare rel_err < TENPM5 would read that as convergence and break on
+                # the first iteration, leaving ef at its starting value.
+                if np.abs(rel_err) < Hamcts.TENPM5:
                     efermi = evbm - (np.log(ef) * self.temperature)
                     break
                 elif rel_err > Hamcts.TENPM5:
@@ -1618,8 +1622,8 @@ class EPC_calculator(object):
             all_eigens = k_row_comm.bcast(all_eigens, root=0)
 
         # Mark the k points outside the energy window and keep only the active ones.
-        rate_all[all_eigens > efocus_max] = np.inf
-        active_k_mask = np.any(all_eigens <= efocus_max, axis=0)
+        rate_all[(all_eigens > efocus_max) | (all_eigens < efocus_min)] = np.inf
+        active_k_mask = np.any((all_eigens <= efocus_max) & (all_eigens >= efocus_min), axis=0)
         active_k_indices = np.where(active_k_mask)[0]
         n_active = len(active_k_indices)
         if self.rank == 0:
@@ -2193,8 +2197,8 @@ class EPC_calculator(object):
             self.comm.allgather(np.ascontiguousarray(eigen_local, dtype=np.float64)), axis=1) # (nbands, nks)
 
         # Mark the k points outside the energy window and keep only the active ones.
-        rate_all[all_eigens > efocus_max] = np.inf
-        active_k_mask = np.any(all_eigens <= efocus_max, axis=0)
+        rate_all[(all_eigens > efocus_max) | (all_eigens < efocus_min)] = np.inf
+        active_k_mask = np.any((all_eigens <= efocus_max) & (all_eigens >= efocus_min), axis=0)
         active_k_indices = np.where(active_k_mask)[0]
         n_active = len(active_k_indices)
         if self.rank == 0:
@@ -2495,8 +2499,8 @@ class EPC_calculator(object):
             all_eigens = k_row_comm.bcast(all_eigens, root=0)
 
         # Mark the k points outside the energy window and keep only the active ones.
-        rate_all[all_eigens > efocus_max] = np.inf
-        active_k_mask = np.any(all_eigens <= efocus_max, axis=0)
+        rate_all[(all_eigens > efocus_max) | (all_eigens < efocus_min)] = np.inf
+        active_k_mask = np.any((all_eigens <= efocus_max) & (all_eigens >= efocus_min), axis=0)
         active_k_indices = np.where(active_k_mask)[0]
         n_active = len(active_k_indices)
         if self.rank == 0:
@@ -2794,8 +2798,13 @@ class EPC_calculator(object):
                 self.efermi * Hamcts.HARTREEtoEV, self.carrier_density * self.inv_cell / (Hamcts.BOHRtoCM ** 3)
                 ))
             
-        ecbm = self._get_ecbm(enks, iband_edge)
-        
+        # The band edge the window is measured from: the CBM for electrons, the VBM for
+        # holes.  The scattering routines take it as `ecbm` either way.
+        if self.ishole:
+            ecbm = self._get_evbm(enks, iband_edge)
+        else:
+            ecbm = self._get_ecbm(enks, iband_edge)
+
         # k points are parallelized and k grid is split
         split_sections = np.zeros(self.rank_size, dtype=int)
         for i in range(len(grid_all)):


### PR DESCRIPTION
## What this changes

The energy window below the VBM is defined but only half applied — three places
still assume the electron case.

**The band edge.** `mobility_cal` always takes the CBM as the edge the window is
measured from, so for holes `efocus_min` sits a band gap away from where it
belongs.

**The k-point pre-selection.** `active_k_mask` tests the upper bound alone. For
holes that bound is infinite, so every k point passes and the whole mesh enters
the main loop. The per-band test inside the loop still rejects them, so the
result survives but the cost does not.

**The rate marking.** The same one-sided test marks rates outside the window, so
for holes nothing is marked and those entries keep their initial zero instead of
becoming infinite — the opposite of what the mobility sum reads them as.

This tests both bounds in all three places and takes the VBM as the band edge
when `ishole` is set.

Two further fixes to the hole Fermi level:

The residual is now tested on its magnitude, as the electron branch already
does. The underflow case sets it to a large negative number meaning "too few
holes, raise ef", which a bare less-than test reads as convergence: the
bisection breaks on its first iteration and returns the Fermi level implied by
the starting bracket, far outside the gap.

The bracket now spans both sides of the band edge. `ef` sets the Fermi level
through `efermi = evbm - log(ef) * T`, so `ef < 1` places it above the VBM and
`ef > 1` places it inside the valence bands; bracketing at an upper bound of one
excludes the degenerate case, where the bisection cannot reach the root.

## Compatibility

For electrons `efocus_min` is negative infinity, so the added comparisons are
identically true or false and that path is unchanged. Carrier densities that put
the Fermi level in the gap converge to the same value as before, the root being
interior to both brackets.

Only `HamEPC/EPC_calculator.py` is modified.