### PR TITLE
Take the cell-pair sum out of the branch loop in EPC_cal_path

### DIFF
--- a/HamEPC/EPC_calculator.py
+++ b/HamEPC/EPC_calculator.py
@@ -727,18 +727,27 @@ class EPC_calculator(object):
 
             tmp1 = np.einsum('m,n -> mn', np.conj(wave_coe2), wave_coe1)
             # calculate epc
+            #
+            # The sum over cell pairs carries no branch index, so it is taken once per q
+            # rather than once per (q, branch): the two cell phases become an outer
+            # product that contracts the gradient tensor over both cell axes, and the
+            # electronic overlap then reduces what is left to the displaced-atom and
+            # Cartesian axes.  Every branch is finally contracted in one einsum.
+            _phase_kpq_cut = np.conj(phase_kpq[self.cell_cut_list]).astype(np.complex128)
+            _phase_k_cut = phase_k[self.cell_cut_list].astype(np.complex128)
+            phase_mat = np.outer(_phase_kpq_cut, _phase_k_cut) # (ncells_cut, ncells_cut)
+            grad_ph = np.einsum('AB, ABmnij -> mnij', phase_mat, self.grad_mat)
+            epc_elec = np.einsum('mn, mnij -> ij', tmp1, grad_ph) # (natoms, 3)
+            factor_all = 1.0 / np.sqrt(2.0 * self.atomic_mass[None, :] * freq[:, None])
+            epc_branch = np.einsum('ij, vij, vi -> v', epc_elec, phvec_wap, factor_all)
+
             for branch_idx in range(int(3*len(self.atomic_mass))):
-                factor = 1.0 / np.sqrt(2.0 * self.atomic_mass * freq[branch_idx]) # shape:(natoms,)
-                tmp2 = np.einsum('ij,mn -> mnij', factor[:,None]*phvec_wap[branch_idx], tmp1)
-                
-                epc = 0.0
-                for i_m, m in enumerate(self.cell_cut_list): # ncells
-                    for i_n, n in enumerate(self.cell_cut_list): # ncells 
-                        epc += np.conj(phase_kpq[m])*phase_k[n]*np.einsum('mnij,mnij', tmp2, self.grad_mat[i_m,i_n])
+                epc = epc_branch[branch_idx]
 
                 # Correction of long-range interactions
                 if self.apply_correction and (np.linalg.norm(q) < self.q_cut):
-                    epc_corr = self._dipole_correction(tmp1, k_fix, q, factor, phvec_wap[branch_idx])
+                    epc_corr = self._dipole_correction(tmp1, k_fix, q, factor_all[branch_idx],
+                                                       phvec_wap[branch_idx])
                 else:
                     epc_corr = 0.0
                 epc_all.append(epc + epc_corr)


### PR DESCRIPTION
## What this changes

The coupling for one q point is accumulated over pairs of unit cells inside the
loop over phonon branches, so the double sum over cells is repeated once per
branch even though it carries no branch index.

This folds it out. The two cell phases form an outer product that contracts the
gradient tensor over both cell axes in one call, the electronic overlap reduces
what is left to the displaced-atom and Cartesian axes, and every branch is then
contracted in a single einsum. What was a sum of ncells² small contractions per
branch becomes one contraction per q point.

The long-range correction still runs per branch and takes the same prefactor it
did before.

## Validation

The rewritten contraction was checked element by element against the original
nested loops over several basis and cell-count combinations, for both a real and
a complex gradient tensor, with deliberately wrong contraction orders as negative
controls.

End to end, the dispersion written along a high-symmetry path agrees with the
current code to eleven significant figures; the residual is the reordering of a
floating-point sum, since the cell pairs are now contracted in one call rather
than accumulated one at a time.

Only `HamEPC/EPC_calculator.py` is modified.